### PR TITLE
Replace state saving/loading with serialization/deserialization (for rewinding)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,12 @@
 	<dict>
 		<key>openemu.system.fds</key>
 		<dict>
+			<key>OEGameCoreRewindBufferSeconds</key>
+			<integer>3600</integer>
+			<key>OEGameCoreRewindInterval</key>
+			<integer>0</integer>
+			<key>OEGameCoreSupportsRewinding</key>
+			<true/>
 			<key>OEGameCoreRequiresFiles</key>
 			<true/>
 			<key>OEGameCoreSupportsCheatCode</key>
@@ -48,6 +54,12 @@
 		</dict>
 		<key>openemu.system.nes</key>
 		<dict>
+			<key>OEGameCoreRewindBufferSeconds</key>
+			<integer>3600</integer>
+			<key>OEGameCoreRewindInterval</key>
+			<integer>0</integer>
+			<key>OEGameCoreSupportsRewinding</key>
+			<true/>
 			<key>OEGameCoreSupportsCheatCode</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
Implementations for `saveStateToFileAtPath:` and `loadStateFromFileAtPath:` have been replaced with `serializeStateWithError:` and `deserializeState: withError:`, respectively. The internal logic is mostly the same; the main difference is that, rather than saving to/loading from `std::fstream`s, states are saved to/loaded from `std::stringstream`s, then the resulting bytes are copied into an `NSData` object.

This enables support for rewinding, as described in OpenEmu/OpenEmu-SDK#8.
